### PR TITLE
Fix refunds

### DIFF
--- a/app/models/spree/amazon_transaction.rb
+++ b/app/models/spree/amazon_transaction.rb
@@ -44,7 +44,7 @@ module Spree
     end
 
     def can_credit?(payment)
-      (payment.pending? || payment.checkout?) && payment.amount < 0
+      payment.completed? && payment.credit_allowed > 0
     end
 
     def can_void?(payment)
@@ -52,7 +52,7 @@ module Spree
     end
 
     def can_close?(payment)
-      !payment.closed?
+      payment.pending?
     end
 
     def actions

--- a/app/models/spree/gateway/amazon.rb
+++ b/app/models/spree/gateway/amazon.rb
@@ -68,7 +68,7 @@ module Spree
       capture(amount, amazon_checkout, gateway_options)
     end
 
-    def credit(amount, _response_code, gateway_options)
+    def credit(amount, _response_code, gateway_options = {})
       payment = gateway_options[:originator].payment
       amazon_transaction = payment.source
 

--- a/app/views/spree/admin/payments/source_views/_amazon.html.erb
+++ b/app/views/spree/admin/payments/source_views/_amazon.html.erb
@@ -17,15 +17,11 @@
       </dl>
     </div>
 
-    <% if payment.state != 'void' %>
-      <%= button_link_to Spree.t('actions.refund', :scope => :amazon), "#", :icon => 'icon-dollar' %>
-    <% else %>
-      <div class="alpha six columns">
-        <dl>
-          <dt><%= Spree.t(:state, :scope => :amazon) %>:</dt>
-          <dd><%= payment.state.titleize %></dd>
-        </dl>
-      </div>
-    <% end %>
+    <div class="alpha six columns">
+      <dl>
+        <dt><%= Spree.t(:state, :scope => :amazon) %>:</dt>
+        <dd><%= payment.state.titleize %></dd>
+      </dl>
+    </div>
   </div>
 </fieldset>

--- a/lib/solidus_amazon_payments/factories.rb
+++ b/lib/solidus_amazon_payments/factories.rb
@@ -8,8 +8,9 @@
 #
 ##
 FactoryGirl.define do
-  # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
-  #
-  # Example adding this to your spec_helper will load these Factories for use:
-  # require 'solidus_amazon_payments/factories'
+  factory :amazon_transaction, class: Spree::AmazonTransaction do
+    authorization_id "AUTHORIZATION_ID"
+    capture_id "CAPTURE_ID"
+    order_reference "ORDER_REFERENCE"
+  end
 end

--- a/spec/models/spree/gateway/amazon_spec.rb
+++ b/spec/models/spree/gateway/amazon_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Spree::Gateway::Amazon do
+  describe "#credit" do
+    it "calls credit on mws with the correct parameters" do
+      gateway = create_gateway
+      mws = stub_mws
+      amazon_transaction = create(:amazon_transaction, capture_id: "CAPTURE_ID")
+      payment = create(:payment, source: amazon_transaction, amount: 30.0, payment_method: gateway)
+      refund = create(:refund, payment: payment, amount: 30.0)
+      allow(mws).to receive(:refund).and_return({})
+
+      gateway.credit(3000, nil, { originator: refund })
+
+      expect(mws).to have_received(:refund).with("CAPTURE_ID", payment.number, 30.0, "USD")
+    end
+  end
+
+  def stub_mws
+    mws = instance_double(AmazonMws)
+    allow(AmazonMws).to receive(:new).and_return(mws)
+    mws
+  end
+
+  def create_gateway
+    described_class.create!(name: 'Amazon', preferred_test_mode: true)
+  end
+end

--- a/spec/models/spree/gateway/amazon_spec.rb
+++ b/spec/models/spree/gateway/amazon_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::Gateway::Amazon do
   describe "#credit" do
-    it "calls credit on mws with the correct parameters" do
+    it "calls refund on mws with the correct parameters" do
       gateway = create_gateway
       mws = stub_mws
       amazon_transaction = create(:amazon_transaction, capture_id: "CAPTURE_ID")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,8 @@ require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 
+require 'solidus_amazon_payments/factories'
+
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 


### PR DESCRIPTION
#### What's this PR do?

With this PR we should now be able to issue refunds from Spree.
#### Notes

There's still some work to be done, specially in `Spree::Amazon::Gateway` since there is no error validation and it's always returning a successful `ActiveMerchant::Billing::Response` but I'll leave that for a better day :)
