### PR TITLE
Move amazon payments configuration into its own class

### DIFF
--- a/app/controllers/spree/admin/amazon_controller.rb
+++ b/app/controllers/spree/admin/amazon_controller.rb
@@ -8,17 +8,15 @@
 #
 ##
 class Spree::Admin::AmazonController < Spree::Admin::BaseController
-  respond_to :html
-
   def edit
-    @amazon_callback_url = "#{root_url}amazon_callback"
   end
 
   def update
-    Spree::Config[:amazon_client_id]=params[:amazon_client_id]
-    Spree::Config[:amazon_merchant_id] = params[:amazon_merchant_id]
-    Spree::Config[:amazon_aws_access_key_id] = params[:amazon_aws_access_key_id]
-    Spree::Config[:amazon_aws_secret_access_key] = params[:amazon_aws_secret_access_key]
+    params.each do |key, value|
+      next unless SpreeAmazon::Config.has_preference? key
+      SpreeAmazon::Config[key] = value
+    end
+
     flash[:success] = Spree.t(:successfully_updated, :resource => Spree.t(:amazon_settings))
     redirect_to edit_admin_amazon_path
   end

--- a/app/models/spree_amazon/configuration.rb
+++ b/app/models/spree_amazon/configuration.rb
@@ -1,0 +1,10 @@
+class SpreeAmazon::Configuration < Spree::Preferences::Configuration
+  preference :client_id, :string
+  preference :merchant_id, :string
+  preference :aws_access_key_id, :string
+  preference :aws_secret_access_key, :string
+
+  def use_static_preferences!
+    raise "SpreeAmazon::Configuration cannot use static preferences"
+  end
+end

--- a/app/views/spree/admin/amazon/edit.html.erb
+++ b/app/views/spree/admin/amazon/edit.html.erb
@@ -12,36 +12,35 @@
   <%= Spree.t(:amazon_settings) %>
 <% end %>
 
-<p><a href="https://sellercentral.amazon.com/hz/me/sp/signup?solutionProviderOptions=lwa%3Bmws-acc%3B&marketplaceId=AGWSWK15IEJJ7&solutionProviderToken=AAAAAQAAAAEAAAAQw%2B2XzpFj2GWN0gTo0twkdAAAAHAcjkEL%2FdK5mKZbaJyrLpiWRmzHCLnC5eLDc8TlCy4aHUaagtgrQcxbsBRi5Y3xsRv1jXEP2QFuCAniHYcBxE%2FpbFnuBaEBPHBANejgd8xYL4fBX8Fz3I9%2Fl5bmIYBWyvSCEP8MPJQ6KKCNwPGcV%2FDN&solutionProviderId=A31NP5KFHXSFV1">Login to get your keys</a>.</p>
 <%= form_tag admin_amazon_path, :method => :put do %>
   <div id="preferences" data-hook>
     <fieldset class="general no-border-top">
-      <div class="form-group">
+      <div class="field">
         <%= label_tag "Amazon Client Id" %>
-        <%= text_field_tag :amazon_client_id, Spree::Config[:amazon_client_id], class: 'fullwidth' %>
+        <%= text_field_tag :client_id, SpreeAmazon::Config[:client_id], class: 'fullwidth' %>
       </div>
 
-      <div class="form-group">
+      <div class="field">
         <%= label_tag "Amazon Seller Id" %>
-        <%= text_field_tag :amazon_merchant_id, Spree::Config[:amazon_merchant_id], class: 'fullwidth' %>
+        <%= text_field_tag :merchant_id, SpreeAmazon::Config[:merchant_id], class: 'fullwidth' %>
       </div>
 
-      <div class="form-group">
+      <div class="field">
         <%= label_tag "Amazon MWS Access Key" %>
-        <%= text_field_tag :amazon_aws_access_key_id, Spree::Config[:amazon_aws_access_key_id], class: 'fullwidth' %>
+        <%= text_field_tag :aws_access_key_id, SpreeAmazon::Config[:aws_access_key_id], class: 'fullwidth' %>
       </div>
 
-      <div class="form-group">
+      <div class="field">
         <%= label_tag "Amazon MWS Secret Key" %>
-        <%= text_field_tag :amazon_aws_secret_access_key, Spree::Config[:amazon_aws_secret_access_key], class: 'fullwidth' %>
+        <%= text_field_tag :aws_secret_access_key, SpreeAmazon::Config[:aws_secret_access_key], class: 'fullwidth' %>
       </div>
 
-      <div class="form-group">
+      <div class="field">
         <%= label_tag "Amazon Callback Url" %>
-        <%= text_field_tag :amazon_callback_url, @amazon_callback_url, class: 'fullwidth', disabled: true %>
+        <%= text_field_tag :amazon_callback_url, spree.amazon_callback_url, class: 'fullwidth', disabled: true %>
       </div>
 
-      <div class="form-actions" data-hook="buttons">
+      <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button Spree.t('actions.update'), 'save' %>
         <span class="or"><%= Spree.t(:or) %></span>
         <%= button_link_to Spree.t('actions.cancel'), edit_admin_general_settings_url, icon: 'delete' %>

--- a/lib/solidus_amazon_payments/engine.rb
+++ b/lib/solidus_amazon_payments/engine.rb
@@ -18,6 +18,10 @@ module SolidusAmazonPayments
       g.test_framework :rspec
     end
 
+    initializer "spree.amazon.config", :before => :load_config_initializers do |app|
+      SpreeAmazon::Config = SpreeAmazon::Configuration.new
+    end
+
     initializer "spree.gateway.payment_methods", :after => "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << Spree::Gateway::Amazon
     end

--- a/spec/controllers/spree/admin/amazon_controller_spec.rb
+++ b/spec/controllers/spree/admin/amazon_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Spree::Admin::AmazonController do
+  let(:user) { create(:user) }
+
+  before do
+    allow(controller).to receive_messages :spree_current_user => user
+    user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
+  end
+
+  describe 'PUT #update' do
+    it "updates the amazon payments configuration" do
+      settings = {
+        utf8: '✓',
+        client_id: 'CLIENT_ID',
+        merchant_id: 'MERCHANT_ID',
+        aws_access_key_id: 'AWS_KEY_ID',
+        aws_secret_access_key: 'AWS_SECRET_KEY_ID'
+      }
+
+      spree_put :update, settings
+
+      expect(SpreeAmazon::Config[:client_id]).to eq('CLIENT_ID')
+      expect(SpreeAmazon::Config[:merchant_id]).to eq('MERCHANT_ID')
+      expect(SpreeAmazon::Config[:aws_access_key_id]).to eq('AWS_KEY_ID')
+      expect(SpreeAmazon::Config[:aws_secret_access_key]).to eq('AWS_SECRET_KEY_ID')
+    end
+
+    it "sets a flash message" do
+      settings = {}
+
+      spree_put :update, settings
+
+      expect(flash[:success]).to eq("Amazon Settings has been successfully updated!")
+    end
+  end
+end

--- a/spec/models/spree_amazon/configuration_spec.rb
+++ b/spec/models/spree_amazon/configuration_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe SpreeAmazon::Configuration do
+  describe '#use_static_preferences!' do
+    it "raises an error" do
+      configuration = SpreeAmazon::Configuration.new
+
+      expect {
+        configuration.use_static_preferences!
+      }.to raise_error("SpreeAmazon::Configuration cannot use static preferences")
+    end
+  end
+end

--- a/spec/models/spree_amazon/configuration_spec.rb
+++ b/spec/models/spree_amazon/configuration_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe SpreeAmazon::Configuration do
   describe '#use_static_preferences!' do
+    # We cannot use_static_preferences since we allow users
+    # to configure the settings through the admin UI, calling
+    # use_static_preferences will reset all settings to their
+    # default values and store them in memory
     it "raises an error" do
       configuration = SpreeAmazon::Configuration.new
 


### PR DESCRIPTION
#### What's this PR do?

With this PR we'll store all of the amazon configuration into `SpreeAmazon::Config` that will always store the values in the database, this way we can still rely on the admin UI.
