### PR TITLE
Remove explicit sass-rails dependency

### DIFF
--- a/spree_amazon_payments.gemspec
+++ b/spree_amazon_payments.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 3.1'
-  s.add_development_dependency 'sass-rails', '~> 6.0.0.beta1'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
This was giving me an error like this:

```
Generating dummy Rails application...
Setting up dummy database...
bundle exec rake db:drop db:create db:migrate
rake aborted!
Sprockets::Railtie::ManifestNeededError: Expected to find a manifest file in `app/assets/config/manifest.js`
But did not, please create this file and use it to link any assets that need
to be rendered by your app
```

I don't think we need to require this as a development dependency at
all in this extension.
