### PR TITLE
Restore requiring core in engine

### DIFF
--- a/lib/solidus_amazon_payments/engine.rb
+++ b/lib/solidus_amazon_payments/engine.rb
@@ -9,7 +9,7 @@
 ##
 module SolidusAmazonPayments
   class Engine < Rails::Engine
-    #require 'spree/core'
+    require 'spree/core'
     isolate_namespace Spree
     engine_name 'solidus_amazon_payments'
 


### PR DESCRIPTION
Without this I get this error:

```
$ bundle exec rails generate migration Foobar
uninitialized constant SolidusAmazonPayments::Engine::Spree (NameError)
solidus_amazon_payments/lib/solidus_amazon_payments/engine.rb:13:in `<class:Engine>'
```
