### PR TITLE
Remove `CaptureNow` from authorize

### DIFF
--- a/lib/amazon_mws.rb
+++ b/lib/amazon_mws.rb
@@ -73,7 +73,6 @@ class AmazonMws
       "AuthorizationReferenceId" => ref_number,
       "AuthorizationAmount.Amount" => total,
       "AuthorizationAmount.CurrencyCode" => currency,
-      "CaptureNow" => Spree::Config[:auto_capture],
       "TransactionTimeout" => 0
     })
   end


### PR DESCRIPTION
When `Spree::Config[:auto_capture]` is enabled then
`Spree::Gateway::Amazon#purchase` will get called, which does this:

```
authorize(amount, amazon_checkout, gateway_options)
capture(amount, amazon_checkout, gateway_options)
```

So we don't want `authorize` to perform a capture, because we'll be
capturing immediately afterward and the second capture would fail.

Note: The best way I can think of to test something like this would be
via an integration test (with some VCR cassettes perhaps) and we
don't have that yet.  It would be great to start making some integration
specs at some point.
