### PR TITLE
Better usage of Payment#number

### DIFF
--- a/app/models/spree/gateway/amazon.rb
+++ b/app/models/spree/gateway/amazon.rb
@@ -70,12 +70,18 @@ module Spree
       if amount < 0
         return ActiveMerchant::Billing::Response.new(true, "Success", {})
       end
-      order = Spree::Order.find_by(:number => gateway_options[:order_id].split("-")[0])
+      order_number, payment_number = gateway_options[:order_id].split("-", 2)
+      order = Spree::Order.find_by!(number: order_number)
+      payment = Spree::Payment.find_by!(number: payment_number)
+      authorization_reference_id = "#{payment.number}-#{random_suffix}"
+
       load_amazon_mws(order.amazon_order_reference_id)
-      response = @mws.authorize(gateway_options[:order_id], amount / 100.0, order.currency)
+
+      response = @mws.authorize(authorization_reference_id, amount / 100.0, order.currency)
       if response["ErrorResponse"]
         return ActiveMerchant::Billing::Response.new(false, response["ErrorResponse"]["Error"]["Message"], response)
       end
+
       t = order.amazon_transaction
       t.authorization_id = response["AuthorizeResponse"]["AuthorizeResult"]["AuthorizationDetails"]["AmazonAuthorizationId"]
       t.save
@@ -86,11 +92,16 @@ module Spree
       if amount < 0
         return credit(amount.abs, nil, nil, gateway_options)
       end
-      order = Spree::Order.find_by(:number => gateway_options[:order_id].split("-")[0])
+      order_number, payment_number = gateway_options[:order_id].split("-", 2)
+      order = Spree::Order.find_by!(number: order_number)
+      payment = Spree::Payment.find_by!(number: payment_number)
+      authorization_id = order.amazon_transaction.authorization_id
+      capture_reference_id = "#{payment.number}-#{random_suffix}"
+
       load_amazon_mws(order.amazon_order_reference_id)
 
-      authorization_id = order.amazon_transaction.authorization_id
-      response = @mws.capture(authorization_id, "C#{Time.now.to_i}", amount / 100.00, order.currency)
+      response = @mws.capture(authorization_id, capture_reference_id, amount / 100.00, order.currency)
+
       t = order.amazon_transaction
       t.capture_id = response.fetch("CaptureResponse", {}).fetch("CaptureResult", {}).fetch("CaptureDetails", {}).fetch("AmazonCaptureId", nil)
       t.save!
@@ -109,7 +120,7 @@ module Spree
       load_amazon_mws(amazon_transaction.order_reference)
       response = @mws.refund(
         amazon_transaction.capture_id,
-        payment.number,
+        "#{payment.number}-#{random_suffix}",
         amount / 100.00,
         payment.currency
       )
@@ -134,6 +145,12 @@ module Spree
 
     def load_amazon_mws(reference)
       @mws ||= AmazonMws.new(reference, gateway: self)
+    end
+
+    # A random string of lowercase alphanumeric characters (i.e. "base 36")
+    def random_suffix
+      length = 10
+      SecureRandom.random_number(36 ** length).to_s(36).rjust(length, '0')
     end
   end
 end

--- a/app/models/spree/gateway/amazon.rb
+++ b/app/models/spree/gateway/amazon.rb
@@ -70,10 +70,10 @@ module Spree
       if amount < 0
         return ActiveMerchant::Billing::Response.new(true, "Success", {})
       end
-      order_number, payment_number = gateway_options[:order_id].split("-", 2)
+      order_number, payment_number = extract_order_and_payment_number(gateway_options)
       order = Spree::Order.find_by!(number: order_number)
       payment = Spree::Payment.find_by!(number: payment_number)
-      authorization_reference_id = "#{payment.number}-#{random_suffix}"
+      authorization_reference_id = operation_unique_id(payment)
 
       load_amazon_mws(order.amazon_order_reference_id)
 
@@ -92,11 +92,11 @@ module Spree
       if amount < 0
         return credit(amount.abs, nil, nil, gateway_options)
       end
-      order_number, payment_number = gateway_options[:order_id].split("-", 2)
+      order_number, payment_number = extract_order_and_payment_number(gateway_options)
       order = Spree::Order.find_by!(number: order_number)
       payment = Spree::Payment.find_by!(number: payment_number)
       authorization_id = order.amazon_transaction.authorization_id
-      capture_reference_id = "#{payment.number}-#{random_suffix}"
+      capture_reference_id = operation_unique_id(payment)
 
       load_amazon_mws(order.amazon_order_reference_id)
 
@@ -120,7 +120,7 @@ module Spree
       load_amazon_mws(amazon_transaction.order_reference)
       response = @mws.refund(
         amazon_transaction.capture_id,
-        "#{payment.number}-#{random_suffix}",
+        operation_unique_id(payment),
         amount / 100.00,
         payment.currency
       )
@@ -145,6 +145,18 @@ module Spree
 
     def load_amazon_mws(reference)
       @mws ||= AmazonMws.new(reference, gateway: self)
+    end
+
+    def extract_order_and_payment_number(gateway_options)
+      gateway_options[:order_id].split("-", 2)
+    end
+
+    # Amazon requires unique ids. Calling with the same id multiple times means
+    # the result of the previous call will be returned again. This can be good
+    # for things like asynchronous retries, but would break things like multiple
+    # captures on a single authorization.
+    def operation_unique_id(payment)
+      "#{payment.number}-#{random_suffix}"
     end
 
     # A random string of lowercase alphanumeric characters (i.e. "base 36")

--- a/app/views/spree/admin/payments/source_views/_amazon.html.erb
+++ b/app/views/spree/admin/payments/source_views/_amazon.html.erb
@@ -12,8 +12,8 @@
   <div class="row">
     <div class="alpha six columns">
       <dl>
-        <dt><%= Spree.t(:payer_id, :scope => :amazon) %>:</dt>
-        <dd><%= payment.number %></dd>
+        <dt><%= Spree.t(:order_reference_id, :scope => :amazon) %>:</dt>
+        <dd><%= payment.order.amazon_order_reference_id %></dd>
       </dl>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,4 @@ en:
     merchant_id: Merchant ID
     aws_access_key_id: AWS Access Key ID
     aws_secret_access_key: AWS Secret Access Key
+    order_reference_id: Order Reference ID

--- a/spec/controllers/spree/amazon_controller_spec.rb
+++ b/spec/controllers/spree/amazon_controller_spec.rb
@@ -250,7 +250,6 @@ describe Spree::AmazonController do
 
       payment = order.payments.amazon.first
       transaction = payment.source
-      expect(payment.number).to eq('ORDER_REFERENCE')
       expect(payment.payment_method).to be_a(Spree::Gateway::Amazon)
       expect(transaction.order_reference).to eq('ORDER_REFERENCE')
       expect(transaction.order_id).to eq(order.id)


### PR DESCRIPTION
- Allow multiple operations on a single payment by appending a random
  suffix to the various identifiers. (e.g. previously you couldn't apply multiple
  partial refunds to a single payment)
- Show the order reference number explicitly in the admin, not the
  payment number.
- Do not set the payment number to the order reference id. This is not
  how the payment number is supposed to be used.
