### PR TITLE
Fix for Gateway::Amazon#purchase when authorization fails

### DIFF
--- a/app/models/spree/gateway/amazon.rb
+++ b/app/models/spree/gateway/amazon.rb
@@ -98,8 +98,12 @@ module Spree
     end
 
     def purchase(amount, amazon_checkout, gateway_options={})
-      authorize(amount, amazon_checkout, gateway_options)
-      capture(amount, amazon_checkout, gateway_options)
+      auth_result = authorize(amount, amazon_checkout, gateway_options)
+      if auth_result.success?
+        capture(amount, amazon_checkout, gateway_options)
+      else
+        auth_result
+      end
     end
 
     def credit(amount, _response_code, gateway_options = {})

--- a/spec/models/spree/gateway/amazon_spec.rb
+++ b/spec/models/spree/gateway/amazon_spec.rb
@@ -57,6 +57,20 @@ describe Spree::Gateway::Amazon do
     end
   end
 
+  describe '#purchase' do
+    context 'when authorization fails' do
+      let(:auth_result) { ActiveMerchant::Billing::Response.new(false, 'Error') }
+
+      it 'returns the authorization result' do
+        expect(payment_method).to receive(:authorize).and_return(auth_result)
+        expect(payment_method).not_to receive(:capture)
+
+        result = payment_method.purchase(order.total, payment_source, {order_id: payment.send(:gateway_order_id)})
+        expect(result).to eq(auth_result)
+      end
+    end
+  end
+
   context 'void' do
     describe 'payment has not yet been captured' do
       it 'cancel succeeds' do


### PR DESCRIPTION
If authorization fails we should stop and return the authorization
response rather than proceeding to attempt a capture.
