### PR TITLE
Add SpreeAmazon::Order#close_order_reference! method

### DIFF
--- a/app/models/spree_amazon/order.rb
+++ b/app/models/spree_amazon/order.rb
@@ -34,7 +34,6 @@ class SpreeAmazon::Order
     if response.success
       true
     else
-      parsed_response = Hash.from_xml(response.body) rescue nil
       message = if parsed_response && parsed_response['ErrorResponse']
         error = parsed_response.fetch('ErrorResponse').fetch('Error')
         "#{response.code} #{error.fetch('Code')}: #{error.fetch('Message')}"

--- a/lib/amazon_mws.rb
+++ b/lib/amazon_mws.rb
@@ -122,13 +122,6 @@ class AmazonMws
       })
   end
 
-  def close(ref_number)
-    process({
-      "Action" => "CloseAuthorization",
-      "AmazonAuthorizationId" => ref_number
-      })
-  end
-
   def cancel(ref_number)
     process({
       "Action" => "CancelOrderReference",

--- a/lib/amazon_mws.rb
+++ b/lib/amazon_mws.rb
@@ -129,6 +129,19 @@ class AmazonMws
       })
   end
 
+  # Amazon's description:
+  # > Call the CloseOrderReference operation to indicate that a previously
+  # > confirmed order reference has been fulfilled (fully or partially) and that
+  # > you do not expect to create any new authorizations on this order
+  # > reference. You can still capture funds against open authorizations on the
+  # > order reference.
+  # > After you call this operation, the order reference is moved into the
+  # > Closed state.
+  # https://payments.amazon.com/documentation/apireference/201752000
+  def close_order_reference
+    client.close_order_reference(@amazon_order_reference_id)
+  end
+
   private
 
   def default_hash

--- a/spec/models/spree/gateway/amazon_spec.rb
+++ b/spec/models/spree/gateway/amazon_spec.rb
@@ -22,11 +22,6 @@ describe Spree::Gateway::Amazon do
   end
   let(:mws) { payment_method.send(:load_amazon_mws, 'REFERENCE') }
 
-  before do
-    # Without this the specs have a big pause while the Amazon gem retries on failures
-    allow_any_instance_of(PayWithAmazon::Request).to receive(:get_seconds_for_try_count).and_return(0)
-  end
-
   describe "#credit" do
     it "calls refund on mws with the correct parameters" do
       amazon_transaction = create(:amazon_transaction, capture_id: "CAPTURE_ID")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,9 @@ RSpec.configure do |config|
   config.before :each do
     DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
+
+    # Without this the specs have a big pause while the Amazon gem retries on failures
+    allow_any_instance_of(PayWithAmazon::Request).to receive(:get_seconds_for_try_count).and_return(0)
   end
 
   # After each spec clean the database.


### PR DESCRIPTION
**NOTE**: Please ignore all but the last two commits here ("Remove unused close method" and "Add SpreeAmazon::Order#close_order_reference! method").  The rest are in other PRs already.  I'm just building on top of them.

Amazon has told us that orders should be "closed" after they are fully
captured.

TODO in a separate pull request: Update the frontend controllers to use this
method, or have it triggered automatically in the correct place.

cc @chrisradford
