### PR TITLE
Fix WebMock to allow codeclimate

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,8 @@ require 'database_cleaner'
 require 'ffaker'
 require 'webmock/rspec'
 
+WebMock.disable_net_connect!(allow: 'codeclimate.com')
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
As per codeclimate instructions:
https://github.com/codeclimate/ruby-test-reporter/tree/v0.6.0#help-your-gem-is-raising-a-

I introduced webmock here:
https://github.com/boomerdigital/solidus_amazon_payments/commit/6496cef#diff-93830fa29d616f7c87903d08b5b1b29a
which caused codeclimate reporting to break on circleci:
https://circleci.com/gh/boomerdigital/solidus_amazon_payments/107
