### PR TITLE
Allow passing address_consent_token

### DIFF
--- a/app/models/spree_amazon/address.rb
+++ b/app/models/spree_amazon/address.rb
@@ -1,7 +1,11 @@
 class SpreeAmazon::Address
   class << self
-    def find(order_reference, gateway:)
-      response = mws(order_reference, gateway: gateway).fetch_order_data
+    def find(order_reference, gateway:, address_consent_token: nil)
+      response = mws(
+        order_reference,
+        gateway: gateway,
+        address_consent_token: address_consent_token,
+      ).fetch_order_data
       from_response(response)
     end
 
@@ -14,8 +18,12 @@ class SpreeAmazon::Address
 
     private
 
-    def mws(order_reference, gateway:)
-      AmazonMws.new(order_reference, gateway: gateway)
+    def mws(order_reference, gateway:, address_consent_token: nil)
+      AmazonMws.new(
+        order_reference,
+        gateway: gateway,
+        address_consent_token: address_consent_token,
+      )
     end
 
     def attributes_from_response(response)

--- a/app/models/spree_amazon/order.rb
+++ b/app/models/spree_amazon/order.rb
@@ -8,7 +8,7 @@ class SpreeAmazon::Order
   end
 
   attr_accessor :state, :total, :email, :address, :reference_id, :currency,
-                :gateway
+                :gateway, :address_consent_token
 
   def initialize(attributes)
     if !attributes.key?(:gateway)
@@ -57,7 +57,11 @@ class SpreeAmazon::Order
   end
 
   def mws
-    @mws ||= AmazonMws.new(reference_id, gateway: gateway)
+    @mws ||= AmazonMws.new(
+      reference_id,
+      gateway: gateway,
+      address_consent_token: address_consent_token,
+    )
   end
 
   def attributes_from_response(response)

--- a/lib/amazon_mws.rb
+++ b/lib/amazon_mws.rb
@@ -40,17 +40,24 @@ end
 class AmazonMws
   require 'httparty'
 
-  def initialize(amazon_order_reference_id, gateway:)
+  def initialize(amazon_order_reference_id, gateway:, address_consent_token: nil)
     @amazon_order_reference_id = amazon_order_reference_id
     @gateway = gateway
+    @address_consent_token = address_consent_token
   end
 
 
   def fetch_order_data
-    AmazonMwsOrderResponse.new(process({
+    params = {
       "Action"=>"GetOrderReferenceDetails",
       "AmazonOrderReferenceId" => @amazon_order_reference_id,
-    }))
+    }
+    if @address_consent_token
+      params.merge!('AddressConsentToken' => @address_consent_token)
+    end
+    AmazonMwsOrderResponse.new(
+      process(params)
+    )
   end
 
   def set_order_data(total, currency)


### PR DESCRIPTION
So that we can get full address and user information.

> Complete buyer information will only be returned after you have
> confirmed the order reference or have specified a valid
> AddressConsentToken in the GetOrderReferenceDetails operation.

See https://payments.amazon.com/developer/documentation/apireference/201752660
