### PR TITLE
Add close order reference on frontend

### DIFF
--- a/app/models/spree/amazon_transaction.rb
+++ b/app/models/spree/amazon_transaction.rb
@@ -51,9 +51,40 @@ module Spree
       payment.pending?
     end
 
-    def actions
-      %w{capture credit void}
+    def can_close?(payment)
+      payment.completed? && closed_at.nil?
     end
 
+    def actions
+      %w{capture credit void close}
+    end
+
+    def close!(payment)
+      return true if !can_close?(payment)
+
+      amazon_order = SpreeAmazon::Order.new(
+        gateway: payment.payment_method,
+        reference_id: order_reference
+      )
+
+      response = amazon_order.close_order_reference!
+
+      if response.success?
+        update_attributes(closed_at: DateTime.now)
+      else
+        gateway_error(response)
+      end
+    end
+
+    private
+
+    def gateway_error(error)
+      text = error.params['message'] || error.params['response_reason_text'] || error.message
+
+      logger.error(Spree.t(:gateway_error))
+      logger.error("  #{error.to_yaml}")
+
+      raise Spree::Core::GatewayError.new(text)
+    end
   end
 end

--- a/app/models/spree/amazon_transaction.rb
+++ b/app/models/spree/amazon_transaction.rb
@@ -60,7 +60,7 @@ module Spree
     end
 
     def close!(payment)
-      return true if !can_close?(payment)
+      return true unless can_close?(payment)
 
       amazon_order = SpreeAmazon::Order.new(
         gateway: payment.payment_method,

--- a/app/models/spree/payment/processing_decorator.rb
+++ b/app/models/spree/payment/processing_decorator.rb
@@ -1,0 +1,8 @@
+Spree::Payment::Processing.module_eval do
+
+  def close!
+    return true if !source.respond_to?(:close!)
+
+    source.close!(self)
+  end
+end

--- a/app/models/spree/payment/processing_decorator.rb
+++ b/app/models/spree/payment/processing_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Payment::Processing.module_eval do
 
   def close!
-    return true if !source.respond_to?(:close!)
+    return true unless source.respond_to?(:close!)
 
     source.close!(self)
   end

--- a/app/models/spree_amazon/order.rb
+++ b/app/models/spree_amazon/order.rb
@@ -26,16 +26,27 @@ class SpreeAmazon::Order
     parsed_response = Hash.from_xml(response.body) rescue nil
 
     if response.success
-      true
+      success = true
+      message = 'Success'
     else
+      success = false
       message = if parsed_response && parsed_response['ErrorResponse']
         error = parsed_response.fetch('ErrorResponse').fetch('Error')
         "#{response.code} #{error.fetch('Code')}: #{error.fetch('Message')}"
       else
         "#{response.code} #{response.body}"
       end
-      raise CloseFailure, message
+
     end
+
+    ActiveMerchant::Billing::Response.new(
+      success,
+      message,
+      {
+        'response' => response,
+        'parsed_response' => parsed_response,
+      },
+    )
   end
 
   def save_total

--- a/db/migrate/20160922135652_add_closed_at_to_spree_amazon_transaction.rb
+++ b/db/migrate/20160922135652_add_closed_at_to_spree_amazon_transaction.rb
@@ -1,0 +1,5 @@
+class AddClosedAtToSpreeAmazonTransaction < ActiveRecord::Migration
+  def change
+    add_column :spree_amazon_transactions, :closed_at, :datetime
+  end
+end

--- a/lib/solidus_amazon_payments/factories.rb
+++ b/lib/solidus_amazon_payments/factories.rb
@@ -23,4 +23,11 @@ FactoryGirl.define do
     preferred_aws_access_key_id ''
     preferred_aws_secret_access_key ''
   end
+
+  factory :amazon_payment, class: Spree::Payment do
+    association(:payment_method, factory: :amazon_gateway)
+    association(:source, factory: :amazon_transaction)
+    amount 100.00
+    order
+  end
 end

--- a/spec/models/spree/amazon_transaction_spec.rb
+++ b/spec/models/spree/amazon_transaction_spec.rb
@@ -75,8 +75,29 @@ describe Spree::AmazonTransaction do
     end
 
     it 'should be false if payment is in complete state' do
-      payment.update_attributes(state: 'complete')
+      payment.update_attributes(state: 'completed')
       expect(amazon_transaction.can_void?(payment)).to be false
+    end
+  end
+
+  describe '#can_close?' do
+    it 'should be true if payment is in complete state' do
+      payment.update_attributes(state: 'completed')
+      amazon_transaction.update_attributes(closed_at: nil)
+
+      expect(amazon_transaction.can_close?(payment)).to be true
+    end
+
+    it 'should be false if payment is in pending state' do
+      payment.update_attributes(state: 'pending')
+
+      expect(amazon_transaction.can_close?(payment)).to be false
+    end
+
+    it 'should be false if closed_at is not nil' do
+      amazon_transaction.update_attributes(closed_at: DateTime.now)
+
+      expect(amazon_transaction.can_close?(payment)).to be false
     end
   end
 
@@ -90,5 +111,97 @@ describe Spree::AmazonTransaction do
     it 'should include void' do
       expect(amazon_transaction.actions).to include('void')
     end
+    it 'should include close' do
+      expect(amazon_transaction.actions).to include('close')
+    end
+  end
+
+  describe '#close!' do
+    it 'returns true if payment is not completed' do
+      payment = create(:amazon_payment, state: 'pending')
+      source = payment.source
+
+      expect(source.close!(payment)).to be_truthy
+    end
+
+    it 'returns true if closed_at is not nil' do
+      payment = create(:amazon_payment, state: 'completed')
+      source = payment.source
+      source.update_attributes(closed_at: DateTime.now)
+
+      expect(source.close!(payment)).to be_truthy
+    end
+
+    def stub_close_request(return_values:)
+      stub_request(
+        :post,
+        'https://mws.amazonservices.com/OffAmazonPayments_Sandbox/2013-01-01',
+      ).with(
+        body: hash_including(
+          'Action' => 'CloseOrderReference',
+          'AmazonOrderReferenceId' => 'ORDER_REFERENCE',
+        )
+      ).to_return(
+        return_values,
+      )
+    end
+
+    context 'when successful' do
+      it 'returns true' do
+        payment = create(:amazon_payment, state: 'completed')
+        source = payment.source
+        stub_close_request(
+          return_values: {
+            status: 200,
+            headers: {'content-type' => 'text/xml'},
+            body: build_mws_close_order_reference_success_response,
+          },
+        )
+
+        expect(source.close!(payment)).to be_truthy
+      end
+    end
+
+    context 'when failure' do
+      it 'raises Spree::Core::GatewayError' do
+        payment = create(:amazon_payment, state: 'completed')
+        source = payment.source
+        stub_close_request(
+          return_values: {
+            status: 404,
+            headers: {'content-type' => 'text/xml'},
+            body: build_mws_close_order_reference_failure_response,
+          },
+        )
+
+        expect {
+          source.close!(payment)
+        }.to raise_error(Spree::Core::GatewayError)
+      end
+    end
+  end
+
+  def build_mws_close_order_reference_success_response
+    <<-XML.strip_heredoc
+      <CloseOrderReferenceResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <CloseOrderReferenceResult/>
+        <ResponseMetadata>
+          <RequestId>2766cf23-f468-4800-bdaf-4bd67c7799e5</RequestId>
+        </ResponseMetadata>
+      </CloseOrderReferenceResponse>
+    XML
+  end
+
+  def build_mws_close_order_reference_failure_response
+    <<-XML.strip_heredoc
+      <ErrorResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <Error>
+          <Type>Sender</Type>
+          <Code>InvalidOrderReferenceId</Code>
+          <Message>The OrderReferenceId ORDER_REFERENCE is invalid.</Message>
+        </Error>
+        <RequestId>f16e027d-4a2e-463f-b60c-0c7f61b13be7</RequestId>
+      </ErrorResponse>
+    XML
   end
 end

--- a/spec/models/spree/payment/processing_decorator_spec.rb
+++ b/spec/models/spree/payment/processing_decorator_spec.rb
@@ -19,7 +19,46 @@ describe Spree::Payment::Processing do
       payment = create(:amazon_payment, state: 'completed')
 
       expect(payment).to receive(:close!)
+
       payment.close!
     end
+
+    it 'delegates close! to the payment source' do
+      payment = create(:amazon_payment, state: 'completed')
+      allow_any_instance_of(Spree::AmazonTransaction).to receive(:close!)
+
+      payment.close!
+
+      expect(payment.source).to have_received(:close!)
+    end
+  end
+
+  def stub_close_request
+    stub_request(
+      :post,
+      'https://mws.amazonservices.com/OffAmazonPayments_Sandbox/2013-01-01',
+    ).with(
+      body: hash_including(
+        'Action' => 'CloseOrderReference',
+        'AmazonOrderReferenceId' => 'ORDER_REFERENCE',
+      )
+    ).to_return(
+      {
+        status: 200,
+        headers: {'content-type' => 'text/xml'},
+        body: build_mws_close_order_reference_success_response,
+      }
+    )
+  end
+
+  def build_mws_close_order_reference_success_response
+    <<-XML.strip_heredoc
+      <CloseOrderReferenceResponse xmlns="http://mws.amazonservices.com/schema/OffAmazonPayments/2013-01-01">
+        <CloseOrderReferenceResult/>
+        <ResponseMetadata>
+          <RequestId>2766cf23-f468-4800-bdaf-4bd67c7799e5</RequestId>
+        </ResponseMetadata>
+      </CloseOrderReferenceResponse>
+    XML
   end
 end

--- a/spec/models/spree/payment/processing_decorator_spec.rb
+++ b/spec/models/spree/payment/processing_decorator_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Payment::Processing do
+  describe '#close!' do
+    it 'returns true if payment is already closed' do
+      payment = create(:amazon_payment, state: 'completed')
+      payment.source.update_attributes(closed_at: DateTime.now)
+
+      expect(payment.close!).to be_truthy
+    end
+
+    it 'returns true if payment is not an AmazonTransaction' do
+      payment = create(:payment)
+
+      expect(payment.close!).to be_truthy
+    end
+  end
+end

--- a/spec/models/spree/payment/processing_decorator_spec.rb
+++ b/spec/models/spree/payment/processing_decorator_spec.rb
@@ -14,5 +14,12 @@ describe Spree::Payment::Processing do
 
       expect(payment.close!).to be_truthy
     end
+
+    it 'payment receives close! method' do
+      payment = create(:amazon_payment, state: 'completed')
+
+      expect(payment).to receive(:close!)
+      payment.close!
+    end
   end
 end

--- a/spec/models/spree_amazon/order_spec.rb
+++ b/spec/models/spree_amazon/order_spec.rb
@@ -82,10 +82,9 @@ describe SpreeAmazon::Order do
             body: build_mws_close_order_reference_success_response,
           },
         )
-
         result = order.close_order_reference!
 
-        expect(result).to be_truthy
+        expect(result.message).to eq('Success')
       end
     end
 
@@ -98,10 +97,9 @@ describe SpreeAmazon::Order do
             body: build_mws_close_order_reference_failure_response,
           },
         )
+        result = order.close_order_reference!
 
-        expect {
-          order.close_order_reference!
-        }.to raise_error(SpreeAmazon::Order::CloseFailure)
+        expect(result.message).to eq( "404 InvalidOrderReferenceId: The OrderReferenceId ORDER_REFERENCE is invalid.")
       end
     end
   end


### PR DESCRIPTION
- Add column closed_at to Spree::AmazonTransaction
- Add close action to  Spree::AmazonTransaction
- Add Spree::Payment::Processing#close! method
- Refactored SpreeAmazon::Order#close_order_reference! to respond with ActiveMerchant::Billing::Response
- Add amazon_payment to factories
