### PR TITLE
Update CodeClimate integration

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,8 @@
 #
 ##
 # Run Coverage report
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 
+require 'simplecov'
 SimpleCov.start do
   add_filter 'spec/dummy'
   add_group 'Controllers', 'app/controllers'


### PR DESCRIPTION
After running a bundle update I was getting this message, which
aborted the specs:

> This usage of the Code Climate Test Reporter is now deprecated.
> Since version 1.0, we now require you to run `SimpleCov` in your
> test/spec helper, and then run the provided
> `codeclimate-test-reporter` binary separately to report your results
> to Code Climate.
>
> More information here:
> https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md

It sounds like there are more steps we need to take according to that link,
but this at least gets specs working again.