### PR TITLE
Add some indexes to spree_amazon_transactions

### DIFF
--- a/db/migrate/20161111151249_add_indexes_to_amazon_transactions.rb
+++ b/db/migrate/20161111151249_add_indexes_to_amazon_transactions.rb
@@ -1,0 +1,6 @@
+class AddIndexesToAmazonTransactions < ActiveRecord::Migration
+  def change
+    add_index 'spree_amazon_transactions', 'order_id'
+    add_index 'spree_amazon_transactions', 'order_reference'
+  end
+end


### PR DESCRIPTION
We're using `order_id` and `order_reference` seems like a very likely
field to be searched on.

We could even add a couple more indexes if we'd like, though I'm not
sure it's be worth the overhead.

NOTE: Specs are failing because of #47.