### PR TITLE
Solidus 2.3: Fix deprecation: method_type -> partial_name

### DIFF
--- a/app/models/spree/gateway/amazon.rb
+++ b/app/models/spree/gateway/amazon.rb
@@ -50,8 +50,14 @@ module Spree
       true
     end
 
-    def method_type
-      "amazon"
+    if Spree.solidus_gem_version >= Gem::Version.new('2.3.x')
+      def partial_name
+        'amazon'
+      end
+    else
+      def method_type
+        'amazon'
+      end
     end
 
     def provider_class


### PR DESCRIPTION
Fixes this:

> DEPRECATION WARNING: Spree::Gateway::Amazon is overriding
> PaymentMethod#method_type. This is deprecated and will be removed from Solidus
> 3.0 (override partial_name instead)