### PR TITLE
Fix specs failures from missing payment_method

### DIFF
--- a/app/models/spree/gateway/amazon.rb
+++ b/app/models/spree/gateway/amazon.rb
@@ -18,8 +18,6 @@ module Spree
     preference :aws_secret_access_key, :string
     preference :region, :string, default: 'us'
 
-    has_one :provider
-
     validates :preferred_region, inclusion: { in: REGIONS }
 
     def self.for_currency(currency)

--- a/spec/controllers/spree/amazon_controller_spec.rb
+++ b/spec/controllers/spree/amazon_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::AmazonController do
-  let!(:gateway) { create(:amazon_gateway) }
+  let!(:payment_method) { create(:amazon_gateway) }
 
   describe "GET #address" do
     it "sets the order to the address state" do
@@ -142,6 +142,9 @@ describe Spree::AmazonController do
       }
       allow_any_instance_of(SpreeAmazon::Order).to receive(:confirm).and_return(nil)
       allow_any_instance_of(SpreeAmazon::Order).to receive(:set_order_reference_details).and_return(nil)
+      allow_any_instance_of(Spree::Gateway::Amazon).to receive(:authorize).and_return(
+        ActiveMerchant::Billing::Response.new(true, 'success')
+      )
     end
 
     it "completes the spree order" do
@@ -259,7 +262,7 @@ describe Spree::AmazonController do
     transaction = Spree::AmazonTransaction.create!(
       order_id: order.id, order_reference: 'REFERENCE'
     )
-    order.payments.create!(source: transaction, amount: amount || order.total)
+    create(:payment, order: order, payment_method: payment_method, source: transaction, amount: amount || order.total)
   end
 
   def build_amazon_address(attributes = {})


### PR DESCRIPTION
This is due to the recent Solidus security issue:
https://groups.google.com/forum/#!topic/solidus-security/oU2K7WJ5H5E
Which added `validates :payment_method, presence: true` to `Spree::Payment`.

Previously these specs were actually creating invalid payments (amazon payments
do have payment methods) but it wasn't noticeable because of the lack of
validation.

Note: It looks like Solidus <= 1.3 has other issues still but this still fixes Solidus 1.4 - current (2.4). The other issues can be fixed in a separate PR.