### PR TITLE
Fix pg version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem 'webmock'
 end
 
-gem 'pg'
+gem 'pg', '~> 0.21'
 gem 'mysql2'
 
 gemspec


### PR DESCRIPTION
See solidusio/solidus#2500

Problem is:
> pg 1.0.0 causes activerecord to error as it explicitly depends on ~> 0.18

and pg 1.0.0 was released yesterday.